### PR TITLE
fix type `removableRate` to bigint

### DIFF
--- a/packages/sdk-ethers-v5/src/entities/ChromaticLens.ts
+++ b/packages/sdk-ethers-v5/src/entities/ChromaticLens.ts
@@ -148,7 +148,7 @@ export class ChromaticLens {
             ? BigNumber.from(0)
             : targetTotalLiqBin.freeLiquidity
                 .mul(clbTokenDecimals)
-                .div(targetTotalLiqBin.liquidity),
+                .div(ownedBin.binValue),
         } satisfies OwnedLiquidityBinResult;
       });
 

--- a/packages/sdk-ethers-v5/src/entities/ChromaticLens.ts
+++ b/packages/sdk-ethers-v5/src/entities/ChromaticLens.ts
@@ -24,7 +24,7 @@ export interface OwnedLiquidityBinResult {
   clbBalance: BigNumber;
   clbTotalSupply: BigNumber;
   clbValue: BigNumber;
-  removableRate: number;
+  removableRate: BigNumber;
 }
 
 /**
@@ -145,10 +145,11 @@ export class ChromaticLens {
                 .mul(10 ** clbTokenDecimals)
                 .div(ownedBin.totalSupply),
           removableRate: targetTotalLiqBin.liquidity.isZero()
-            ? 0
-            : Number(targetTotalLiqBin.freeLiquidity.toString() || 0) /
-              Number(targetTotalLiqBin.liquidity.toString()),
-        };
+            ? BigNumber.from(0)
+            : targetTotalLiqBin.freeLiquidity
+                .mul(clbTokenDecimals)
+                .div(targetTotalLiqBin.liquidity),
+        } satisfies OwnedLiquidityBinResult;
       });
 
       return results.filter((bin) => bin.clbBalance.gt(0));

--- a/packages/sdk-ethers-v6/src/entities/ChromaticLens.ts
+++ b/packages/sdk-ethers-v6/src/entities/ChromaticLens.ts
@@ -147,7 +147,7 @@ export class ChromaticLens {
             targetTotalLiqBin.liquidity == 0n
               ? 0n
               : (targetTotalLiqBin.freeLiquidity * 10n ** clbTokenDecimals) /
-                targetTotalLiqBin.liquidity,
+              ownedBin.binValue,
         };
       });
 

--- a/packages/sdk-ethers-v6/src/entities/ChromaticLens.ts
+++ b/packages/sdk-ethers-v6/src/entities/ChromaticLens.ts
@@ -23,7 +23,7 @@ export interface OwnedLiquidityBinResult {
   clbBalance: bigint;
   clbTotalSupply: bigint;
   clbValue: bigint;
-  removableRate: number;
+  removableRate: bigint;
 }
 
 /**
@@ -145,9 +145,9 @@ export class ChromaticLens {
               : ((ownedBin.binValue || 0n) * 10n ** clbTokenDecimals) / ownedBin.totalSupply,
           removableRate:
             targetTotalLiqBin.liquidity == 0n
-              ? 0
-              : Number(targetTotalLiqBin.freeLiquidity.toString() || 0) /
-                Number(targetTotalLiqBin.liquidity.toString()),
+              ? 0n
+              : (targetTotalLiqBin.freeLiquidity * 10n ** clbTokenDecimals) /
+                targetTotalLiqBin.liquidity,
         };
       });
 

--- a/packages/sdk-viem/src/entities/ChromaticLens.ts
+++ b/packages/sdk-viem/src/entities/ChromaticLens.ts
@@ -28,7 +28,7 @@ export interface OwnedLiquidityBinResult {
   clbBalance: bigint;
   clbTotalSupply: bigint;
   clbValue: bigint;
-  removableRate: number;
+  removableRate: bigint;
 }
 
 /**
@@ -154,9 +154,10 @@ export class ChromaticLens {
                 ownedBin.totalSupply,
           removableRate:
             targetTotalLiqBin.liquidity == 0n
-              ? 0
-              : Number(targetTotalLiqBin.freeLiquidity || 0n) / Number(targetTotalLiqBin.liquidity),
-        };
+              ? 0n
+              : ((targetTotalLiqBin.freeLiquidity || 0n) * 10n ** BigInt(clbTokenDecimals)) /
+                ownedBin.binValue,
+        } satisfies OwnedLiquidityBinResult;
       });
       return results.filter((bin) => bin.clbBalance > 0n);
     });


### PR DESCRIPTION
From now on, `removeableRate` is represent bigint type with CLB token decimals
Fixes #187